### PR TITLE
replace: raise an exception when provided both full_path and one of its components

### DIFF
--- a/test.py
+++ b/test.py
@@ -355,6 +355,17 @@ class InterfaceTests(unittest.TestCase):
             url = url.replace(full_path=orig_path)
             self.assertEqual(url.full_path, orig_path)
 
+        # cannot combine full_path with its components
+        url = URL('a://b')
+        for component in ['path', 'query', 'fragment']:
+            kwargs = {component: 'other'}
+            self.assertRaises(TypeError, url.replace, full_path='c?d#e', 
+                              **kwargs)
+
+        # the above check applies to the empty string
+        self.assertRaises(TypeError, url.replace, full_path='c?d#e',
+                          fragment='')
+
     def test_setdefault(self):
         empty = URL()
         full1 = URL('scheme://user@host:80/path?query#frgment')

--- a/yurl/__init__.py
+++ b/yurl/__init__.py
@@ -280,7 +280,7 @@ class URL(URLTuple):
             userinfo, host, port = URL('//' + authority)[1:4]
 
         if full_path is not None:
-            if path or query or fragment:
+            if any(i is not None for i in [path, query, fragment]):
                 raise TypeError()
 
             # Use original URL just for parse.


### PR DESCRIPTION
Fixes #3; the same exception is raised as before (`TypeError`).